### PR TITLE
fix: http keep alive now works

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,11 +59,12 @@ function getTimings (eventTimes) {
     // There is no DNS lookup with IP address
     dnsLookup: eventTimes.dnsLookupAt !== undefined ?
                getHrTimeDurationInMs(eventTimes.socketAssigned, eventTimes.dnsLookupAt) : undefined,
-    tcpConnection: getHrTimeDurationInMs(eventTimes.dnsLookupAt || eventTimes.socketAssigned, eventTimes.tcpConnectionAt),
+    tcpConnection: eventTimes.tcpConnectionAt !== undefined ?
+                getHrTimeDurationInMs(eventTimes.dnsLookupAt || eventTimes.socketAssigned, eventTimes.tcpConnectionAt) : undefined,
     // There is no TLS handshake without https
     tlsHandshake: eventTimes.tlsHandshakeAt !== undefined ?
                   (getHrTimeDurationInMs(eventTimes.tcpConnectionAt, eventTimes.tlsHandshakeAt)) : undefined,
-    firstByte: getHrTimeDurationInMs((eventTimes.tlsHandshakeAt || eventTimes.tcpConnectionAt), eventTimes.firstByteAt),
+    firstByte: getHrTimeDurationInMs((eventTimes.tlsHandshakeAt || eventTimes.tcpConnectionAt || eventTimes.socketAssigned), eventTimes.firstByteAt),
     contentTransfer: getHrTimeDurationInMs(eventTimes.firstByteAt, eventTimes.endAt),
     total: getHrTimeDurationInMs(eventTimes.startAt, eventTimes.endAt)
   }


### PR DESCRIPTION
Thank you for this simple yet great library.

I am using this library for debugging purposes. I have added a custom HTTP Agent to superagent, because I'd like to use HTTP Keep-Alive. I am issuing many requests per second to the same server and establishing a new TCP connection every time is a waste of ressources.

The HTTP agent is created as simple as this example:
```
new http.Agent({
    keepAlive: true
})
```
and then provided to superagent with the `.agent()` method:

```
superagent
	.get("foobar")
    .use(logNetworkTime((err, result) => {
        if (err) {
            console.log(err)
        } else {
            console.log(timing)
        }
    }))
    .send("json obj")
    .timeout(30000)
    .set("Content-Type", "application/json")
    .set("Accept", "application/json")
    .auth("user", "pass")
    .agent(globalThis.HttpAgent)
```

This would give me the following exception:
```
/path/to/app/node_modules/superagent-node-http-timings/index.js:78
  const secondDiff = endTime[0] - startTime[0];
                                           ^
TypeError: Cannot read properties of undefined (reading '0')
    at getHrTimeDurationInMs (/path/to/app/node_modules/superagent-node-http-timings/index.js:78:44)
    at getTimings (/path/to/app/node_modules/superagent-node-http-timings/index.js:68:16)
    at IncomingMessage.<anonymous> (/path/to/app/node_modules/superagent-node-http-timings/index.js:44:22)
    at Stream.emit (node:events:531:35)
    at Unzip.<anonymous> (/path/to/app/node_modules/superagent/src/node/unzip.js:55:12)
    at Unzip.emit (node:events:519:28)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```

After some debugging I found out its due to the HTTP Keep Alive flag. The agent maintains a pool of reusable TCP connections to the server I'm talking to. That means, there is no `tcpConnectionAt` variable, since there is no `connect` event on subsequent HTTP requests.

I have provided a fix.